### PR TITLE
Removes the node project package file

### DIFF
--- a/myrailsapp/package.json
+++ b/myrailsapp/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "myrailsapp",
-  "private": true,
-  "dependencies": {}
-}


### PR DESCRIPTION
This file is useful for node projects not rails projects.

Also if you run `hab plan init` the scaffolding generator
will choose `node` and not `ruby`.

Signed-off-by: Franklin Webber <franklin@chef.io>